### PR TITLE
Fix/inmemory storage race condition

### DIFF
--- a/core-storage/src/commonMain/kotlin/com/reqlab/core/storage/InMemoryRepositories.kt
+++ b/core-storage/src/commonMain/kotlin/com/reqlab/core/storage/InMemoryRepositories.kt
@@ -7,6 +7,7 @@ import com.reqlab.core.model.RequestDefinition
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 
 // ── Shared base ──────────────────────────────────────────────────
 
@@ -28,11 +29,16 @@ abstract class InMemoryMapRepository<T>(
     }
 
     suspend fun upsertEntity(entity: T) {
-        store.value = store.value + (getKey(entity) to entity)
+        store.update { currentValue ->
+            val newPair = (getKey(entity) to entity)
+            currentValue + newPair
+        }
     }
 
     suspend fun deleteEntity(id: String) {
-        store.value = store.value - id
+        store.update { currentValue ->
+            currentValue - id
+        }
     }
 }
 
@@ -73,10 +79,12 @@ class InMemoryHistoryRepository : HistoryRepository {
     }
 
     override suspend fun append(entry: HistoryEntry) {
-        state.value = state.value + entry
+        state.update { currentValue ->
+            currentValue + entry
+        }
     }
 
     override suspend fun clear() {
-        state.value = emptyList()
+        state.update { emptyList() }
     }
 }

--- a/core-storage/src/commonTest/kotlin/com/reqlab/core/storage/InMemoryRepositoriesTest.kt
+++ b/core-storage/src/commonTest/kotlin/com/reqlab/core/storage/InMemoryRepositoriesTest.kt
@@ -5,7 +5,10 @@ import com.reqlab.core.model.EnvironmentDefinition
 import com.reqlab.core.model.HistoryEntry
 import com.reqlab.core.model.HttpMethodType
 import com.reqlab.core.model.RequestDefinition
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -22,6 +25,39 @@ class InMemoryRepositoriesTest {
 
         repository.delete("req-1")
         assertTrue(repository.observeAll().first().isEmpty())
+    }
+
+    @Test
+    fun request_repository_supports_concurrent_upsert_and_delete() = runTest {
+        val repository = InMemoryRequestRepository()
+        val sampleSize = 5
+
+        coroutineScope {
+            repeat(sampleSize) {
+                launch(Dispatchers.Default) {
+                    repository.upsert(sampleRequest("$it"))
+                }
+            }
+        }
+
+        assertEquals(sampleSize, repository.observeAll().first().size)
+
+        coroutineScope {
+            repeat(sampleSize) {
+                if (it % 2 == 0) {
+                    launch(Dispatchers.Default) {
+                        repository.delete("$it")
+                    }
+                }
+            }
+        }
+
+        assertEquals(sampleSize / 2, repository.observeAll().first().size)
+        assertTrue(
+            repository.observeAll().first().all { request ->
+                request.id.toInt() % 2 != 0
+            }
+        )
     }
 
     @Test

--- a/core-storage/src/commonTest/kotlin/com/reqlab/core/storage/InMemoryRepositoriesTest.kt
+++ b/core-storage/src/commonTest/kotlin/com/reqlab/core/storage/InMemoryRepositoriesTest.kt
@@ -30,7 +30,7 @@ class InMemoryRepositoriesTest {
     @Test
     fun request_repository_supports_concurrent_upsert_and_delete() = runTest {
         val repository = InMemoryRequestRepository()
-        val sampleSize = 5
+        val sampleSize = 100
 
         coroutineScope {
             repeat(sampleSize) {
@@ -126,6 +126,34 @@ class InMemoryRepositoriesTest {
 
         val history = repository.observeRecent(limit = 10).first()
         assertEquals(listOf("h-2", "h-1"), history.map { it.id })
+
+        repository.clear()
+        assertTrue(repository.observeRecent().first().isEmpty())
+    }
+
+    @Test
+    fun history_repository_stores_and_orders_concurrent_recent_requests() = runTest {
+        val repository = InMemoryHistoryRepository()
+        val sampleSize = 100
+
+        coroutineScope {
+            repeat(sampleSize) {
+                launch(Dispatchers.Default) {
+                    repository.append(
+                        HistoryEntry(
+                            id = "h-$it",
+                            requestId = "r-$it",
+                            requestSnapshot = sampleRequest("r-$it"),
+                            responseSnapshot = null,
+                            executedAtEpochMillis = 100
+                        )
+                    )
+                }
+            }
+        }
+
+        val history = repository.observeRecent().first()
+        assertEquals(sampleSize, history.size)
 
         repository.clear()
         assertTrue(repository.observeRecent().first().isEmpty())


### PR DESCRIPTION
## Summary
Wrapped the `+` and `-` operators used in methods like `append`, `upsert` and `delete` inside `.update{}` method which make sure these operations are safe to race condition.

## Scope
- Modules touched: `core-storage`
- Platform impact: Desktop / Web / Shared

## Checklist
- [x] I have run relevant local checks (for example):
	- `./gradlew :ui-shared:allTests --no-daemon`
	- `./gradlew :ui-desktop:desktopTest --no-daemon`
	- `./gradlew :qa-tests:jvmTest --no-daemon`
- [ ] CI passes
- [x] I updated documentation if needed
- [x] No secrets committed

## Related issues
Resolves: #4 
